### PR TITLE
Add colorful CLI output with lipbalm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,6 +222,7 @@ dependencies = [
  "anyhow",
  "clap",
  "directories",
+ "lipbalm",
  "postgres",
  "serde",
  "serde_json",
@@ -411,6 +412,12 @@ dependencies = [
  "bitflags",
  "libc",
 ]
+
+[[package]]
+name = "lipbalm"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2699466130ae2858370742c164e1e9ffe8b6d9d9219f86608f97fc29460208f8"
 
 [[package]]
 name = "lock_api"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ serde_json = "1.0"
 directories = "5.0"
 uuid = { version = "1.4", features = ["v4"] }
 anyhow = "1.0"
+lipbalm = "0.1"
 
 [dev-dependencies]
 postgres = "0.19"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ deckard-rs is a robust CLI tool designed for copying databases between environme
 - **Scheduling:** Set up cron jobs for automated data copying tasks.
 - **Data Transformation:** Apply transformations to data before copying to the target environment.
 - **Logging and Monitoring:** Comprehensive logging for effective monitoring and troubleshooting.
+- **Colorful Output:** Stylish CLI output powered by the [lipbalm](https://crates.io/crates/lipbalm) library inspired by charm.sh.
 - **Dry Run Mode:** Simulate copy operations to preview outcomes without actual execution.
 - **Concurrency Control:** Manage concurrent table copies for optimal performance.
 - **Integrity Check:** Post-copy data integrity verification to ensure data consistency.

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -2,6 +2,7 @@ use crate::cli::{CopyArgs, ResumeArgs, ScheduleArgs};
 use crate::config::{Config, DbConfig};
 use anyhow::Result;
 use uuid::Uuid;
+use lipbalm::{colors::Color, Lipbalm};
 
 pub fn config_set(config: &mut Config, env: String, db: DbConfig) -> Result<()> {
     config.envs.insert(env, db);
@@ -14,42 +15,104 @@ pub fn config_get(config: &Config, env: &str) -> Result<Option<DbConfig>> {
 
 pub fn copy_database(args: CopyArgs) -> Result<()> {
     let task_id = Uuid::new_v4();
-    println!("Starting copy task {}", task_id);
-    println!("From {} to {}", args.source, args.target);
+    println!(
+        "{}",
+        Lipbalm::new()
+            .foreground(Color::BrightCyan)
+            .bold(true)
+            .render(&format!("Starting copy task {}", task_id))
+    );
+    println!(
+        "{}",
+        Lipbalm::new()
+            .foreground(Color::Green)
+            .render(&format!("From {} to {}", args.source, args.target))
+    );
     if let Some(tables) = args.tables {
-        println!("Tables: {}", tables);
+        println!(
+            "{}",
+            Lipbalm::new()
+                .foreground(Color::Yellow)
+                .render(&format!("Tables: {}", tables))
+        );
     }
     if let Some(table) = args.table {
-        println!("Table: {}", table);
+        println!(
+            "{}",
+            Lipbalm::new()
+                .foreground(Color::Yellow)
+                .render(&format!("Table: {}", table))
+        );
     }
     if let Some(filter) = args.where_ {
-        println!("Where: {}", filter);
+        println!(
+            "{}",
+            Lipbalm::new()
+                .foreground(Color::Magenta)
+                .render(&format!("Where: {}", filter))
+        );
     }
     if let Some(transform) = args.transform {
-        println!("Transform: {}", transform);
+        println!(
+            "{}",
+            Lipbalm::new()
+                .foreground(Color::Magenta)
+                .render(&format!("Transform: {}", transform))
+        );
     }
     if args.dry_run {
-        println!("Dry run mode");
+        println!(
+            "{}",
+            Lipbalm::new()
+                .foreground(Color::BrightYellow)
+                .render("Dry run mode")
+        );
     }
     if let Some(conc) = args.concurrency {
-        println!("Concurrency: {}", conc);
+        println!(
+            "{}",
+            Lipbalm::new()
+                .foreground(Color::Cyan)
+                .render(&format!("Concurrency: {}", conc))
+        );
     }
     if args.integrity_check {
-        println!("Integrity check enabled");
+        println!(
+            "{}",
+            Lipbalm::new()
+                .foreground(Color::BrightGreen)
+                .render("Integrity check enabled")
+        );
     }
-    println!("Copy operation completed (simulated)");
+    println!(
+        "{}",
+        Lipbalm::new()
+            .foreground(Color::BrightGreen)
+            .bold(true)
+            .render("Copy operation completed (simulated)")
+    );
     Ok(())
 }
 
 pub fn schedule_copy(args: ScheduleArgs) -> Result<()> {
     println!(
-        "Scheduling copy from {} to {} with cron {}",
-        args.source, args.target, args.cron
+        "{}",
+        Lipbalm::new()
+            .foreground(Color::BrightBlue)
+            .render(&format!(
+                "Scheduling copy from {} to {} with cron {}",
+                args.source, args.target, args.cron
+            ))
     );
     Ok(())
 }
 
 pub fn resume_task(args: ResumeArgs) -> Result<()> {
-    println!("Resuming task {}", args.task_id);
+    println!(
+        "{}",
+        Lipbalm::new()
+            .foreground(Color::BrightMagenta)
+            .render(&format!("Resuming task {}", args.task_id))
+    );
     Ok(())
 }


### PR DESCRIPTION
## Summary
- integrate `lipbalm` library for colored CLI output
- colorize copy, schedule and resume commands
- document colorful output feature

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_683f5434647483209983a3e80a505c3b